### PR TITLE
Detect format strings and attribute annotations

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -14,6 +14,7 @@
         { "open": "[", "close": "]", "notIn": ["string", "comment"] },
         { "open": "(", "close": ")", "notIn": ["string", "comment"] },
         { "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
+        { "open": "f\"", "close": "\"", "notIn": ["string", "comment"] },
         { "open": "'", "close": "'", "notIn": ["string", "comment"] },
         { "open": "<", "close": ">", "notIn": ["string", "comment"] }
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1450,9 +1450,9 @@
             }
         },
         "node_modules/ansi-colors": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -2044,9 +2044,9 @@
             "dev": true
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -2086,12 +2086,12 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
             "dev": true,
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -2192,9 +2192,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
@@ -3890,32 +3890,31 @@
             "optional": true
         },
         "node_modules/mocha": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
-            "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+            "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
             "dev": true,
             "dependencies": {
-                "ansi-colors": "4.1.1",
-                "browser-stdout": "1.3.1",
-                "chokidar": "3.5.3",
-                "debug": "4.3.4",
-                "diff": "5.0.0",
-                "escape-string-regexp": "4.0.0",
-                "find-up": "5.0.0",
-                "glob": "7.2.0",
-                "he": "1.2.0",
-                "js-yaml": "4.1.0",
-                "log-symbols": "4.1.0",
-                "minimatch": "5.0.1",
-                "ms": "2.1.3",
-                "nanoid": "3.3.3",
-                "serialize-javascript": "6.0.0",
-                "strip-json-comments": "3.1.1",
-                "supports-color": "8.1.1",
-                "workerpool": "6.2.1",
-                "yargs": "16.2.0",
-                "yargs-parser": "20.2.4",
-                "yargs-unparser": "2.0.0"
+                "ansi-colors": "^4.1.3",
+                "browser-stdout": "^1.3.1",
+                "chokidar": "^3.5.3",
+                "debug": "^4.3.5",
+                "diff": "^5.2.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-up": "^5.0.0",
+                "glob": "^8.1.0",
+                "he": "^1.2.0",
+                "js-yaml": "^4.1.0",
+                "log-symbols": "^4.1.0",
+                "minimatch": "^5.1.6",
+                "ms": "^2.1.3",
+                "serialize-javascript": "^6.0.2",
+                "strip-json-comments": "^3.1.1",
+                "supports-color": "^8.1.1",
+                "workerpool": "^6.5.1",
+                "yargs": "^16.2.0",
+                "yargs-parser": "^20.2.9",
+                "yargs-unparser": "^2.0.0"
             },
             "bin": {
                 "_mocha": "bin/_mocha",
@@ -3923,10 +3922,6 @@
             },
             "engines": {
                 "node": ">= 14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mochajs"
             }
         },
         "node_modules/mocha/node_modules/cliui": {
@@ -3947,51 +3942,29 @@
             "dev": true
         },
         "node_modules/mocha/node_modules/glob": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
             },
             "engines": {
-                "node": "*"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/mocha/node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/mocha/node_modules/minimatch": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-            "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -3999,12 +3972,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/mocha/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
         },
         "node_modules/mocha/node_modules/string-width": {
             "version": "4.2.3",
@@ -4071,9 +4038,9 @@
             }
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
         "node_modules/mute-stream": {
@@ -4081,18 +4048,6 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
-        },
-        "node_modules/nanoid": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-            "dev": true,
-            "bin": {
-                "nanoid": "bin/nanoid.cjs"
-            },
-            "engines": {
-                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
         },
         "node_modules/napi-build-utils": {
             "version": "1.0.2",
@@ -4985,9 +4940,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
@@ -5475,15 +5430,6 @@
                 "uglify-js": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dev": true,
-            "dependencies": {
-                "randombytes": "^2.1.0"
             }
         },
         "node_modules/test-exclude": {
@@ -6027,9 +5973,9 @@
             }
         },
         "node_modules/workerpool": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-            "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
             "dev": true
         },
         "node_modules/wrap-ansi": {
@@ -6173,9 +6119,9 @@
             }
         },
         "node_modules/yargs-parser": {
-            "version": "20.2.4",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-            "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
             "dev": true,
             "engines": {
                 "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nemo",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nemo",
-            "version": "0.0.16",
+            "version": "0.0.17",
             "dependencies": {
                 "@vscode/wasm-wasi": "^0.13.0-pre.1",
                 "@vscode/wasm-wasi-lsp": "^0.1.0-pre.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nemo",
     "displayName": "nemo",
     "description": "",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "repository": {
         "type": "git",
         "url": "https://github.com/knowsys/nemo-vscode-extension.git"

--- a/syntaxes/nemo.tmLanguage.json
+++ b/syntaxes/nemo.tmLanguage.json
@@ -51,9 +51,12 @@
             "begin": "(f)(\")",
             "end": "\"",
             "captures": {
-                "1" : {"name" : "keyword"},
-                "2" : {"name" : "string"}
-
+                "1" : {
+                    "name" : "keyword"
+                },
+                "2" : {
+                    "name" : "string"
+                }
             },
             "patterns": [
                 {
@@ -66,7 +69,6 @@
                 }
             ]
         },
-        
 
         "specialVariable": {
             "name": "variable",

--- a/syntaxes/nemo.tmLanguage.json
+++ b/syntaxes/nemo.tmLanguage.json
@@ -47,22 +47,26 @@
         },           
 
         "fstring": {
-            "match": "(f)(\"[^{]*)(\\{[?0-9a-zA-Z<=>+\\-*/ ]*\\})?([^}]*\")",
+            "name" : "string",
+            "begin": "(f)(\")",
+            "end": "\"",
             "captures": {
-                "1" : {
-                    "name" : "keyword.other" 
+                "1" : {"name" : "keyword"},
+                "2" : {"name" : "string"}
+
+            },
+            "patterns": [
+                {
+                    "name" : "keyword.operator",
+                    "match" : "\\{[^{}]*\\}"
                 },
-                "2" : {
-                    "name" : "string"
-                },
-                "3" : {
-                    "name" : "operator"
-                },
-                "4" : {
-                    "name" : "string"
+                {
+                    "name" : "string",
+                    "match" : "[^{}\"]*"
                 }
-            }
+            ]
         },
+        
 
         "specialVariable": {
             "name": "variable",

--- a/syntaxes/nemo.tmLanguage.json
+++ b/syntaxes/nemo.tmLanguage.json
@@ -3,6 +3,12 @@
     "name": "Nemo Rule Language",
     "patterns": [
         {
+            "include": "#attribute"
+        },
+        {
+            "include": "#fstring"
+        },
+        {
             "include": "#specialDeclation"
         },
         {
@@ -33,7 +39,31 @@
             "include": "#invalid"
         }
     ],
-    "repository": {
+    "repository": {     
+        "attribute": {
+            "name": "entity.name.tag",
+            "begin": "(#\\[)",
+            "end": "(\\])"
+        },           
+
+        "fstring": {
+            "match": "(f)(\"[^{]*)(\\{[?0-9a-zA-Z<=>+\\-*/ ]*\\})?([^}]*\")",
+            "captures": {
+                "1" : {
+                    "name" : "keyword.other" 
+                },
+                "2" : {
+                    "name" : "string"
+                },
+                "3" : {
+                    "name" : "operator"
+                },
+                "4" : {
+                    "name" : "string"
+                }
+            }
+        },
+
         "specialVariable": {
             "name": "variable",
             "match": "\\?[a-zA-Z][a-zA-Z0-9_\\-]*"


### PR DESCRIPTION
Detects attributes with patterns like `#[.*]` that are introduced in https://github.com/knowsys/nemo/pull/565.

Detect format strings, typically `f"sum: {?a+10}!"` related to https://github.com/knowsys/nemo/pull/566.

With this syntax curly braces `{}` inside fstrings are highlighted by vscode and not by the language server.